### PR TITLE
if-not-valid-winner-continue fix to original

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -259,7 +259,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 
             std::string strError = "";
             if (!winner.IsValid(pfrom, strError)) {
-                if(strError != "") //LogPrintf("mnwp - invalid message - %s\n", strError); TO-DO:active again in next big release.
+                //if(strError != "") LogPrintf("mnwp - invalid message - %s\n", strError); TO-DO:active again in next big release.
                 continue;
             }
 


### PR DESCRIPTION
to hide just the print of error log you must comment the line 262 from the if 
or else 'continue' is now only when strError and that was not original flow for above if(!winner.IsValid(pfrom, strError))
Unless this is to hide and allow some 'shady' stuff with your provided bootstrap...